### PR TITLE
Fixed H80 Example 3 typos

### DIFF
--- a/wcag20/sources/techniques/html/H80.xml
+++ b/wcag20/sources/techniques/html/H80.xml
@@ -62,9 +62,9 @@
       </eg-group>
       <eg-group>
          <head>Newspaper Web site</head>
-         <code role="xhtml"><![CDATA[<h2><a href="Stockmarket_05052007.htm>Stock market soars as bullishness prevails</a></h2>
-<p>this week was a stellar week for the stock market as investing in gold rose 2%. 
-<a href="Stockmarket_05052007.htm>More here</a></p>     ]]></code>
+         <code role="xhtml"><![CDATA[<h2><a href="Stockmarket_05052007.htm">Stock market soars as bullishness prevails</a></h2>
+<p>This week was a stellar week for the stock market as investing in gold rose 2%. 
+<a href="Stockmarket_05052007.htm">More here</a></p>     ]]></code>
       </eg-group>
    </examples>
    <resources/>


### PR DESCRIPTION
The code snippet in H80 Example 3 was missing a couple of closing
quotes.  (Also capitalized the T for good measure!).